### PR TITLE
fix shell script for windows env

### DIFF
--- a/scripts/build-app.js
+++ b/scripts/build-app.js
@@ -1,9 +1,3 @@
 const shell = require('shelljs')
 
-shell.exec(`
-  npx vue-cli-service build \
-  --mode production \
-  --target app \
-  --dest dist \
-  --report
-`)
+shell.exec('npx vue-cli-service build --mode production --target app --dest dist --report')

--- a/scripts/build-esm.js
+++ b/scripts/build-esm.js
@@ -3,10 +3,4 @@ const shell = require('shelljs')
 const args = process.argv.slice(2)
 const watch = args.includes('--watch')
 shell.rm('-rf', 'publish/esm')
-shell.exec(`
-  npx cross-env NODE_ENV=build_esm babel src \
-  --config-file ./babel.lib.config.js \
-  --out-dir publish/esm/ \
-  --copy-files \
-  ${watch ? '--watch' : ''}
-`)
+shell.exec(`npx cross-env NODE_ENV=build_esm babel src --config-file ./babel.lib.config.js --out-dir publish/esm/  --copy-files ${watch ? '--watch' : ''}`)

--- a/scripts/build-wc.js
+++ b/scripts/build-wc.js
@@ -2,14 +2,5 @@ const shell = require('shelljs')
 
 const args = process.argv.slice(2)
 const watch = args.includes('--watch')
-shell.exec(`
-  export VUE_CLI_SERVICE_BUILD_TARGET=wc && \
-  npx vue-cli-service build \
-  --mode production \
-  --target wc \
-  --name jds \
-  --dest publish/wc \
-  'src/components/**/*.vue' \
-  ${watch ? '--watch' : ''}
-`);
+shell.exec(`export VUE_CLI_SERVICE_BUILD_TARGET=wc && npx vue-cli-service build --mode production --target wc --name jds --dest publish/wc 'src/components/**/*.vue' ${watch ? '--watch' : ''}`);
 shell.rm('publish/wc/demo.html')

--- a/scripts/dev-esm.js
+++ b/scripts/dev-esm.js
@@ -1,8 +1,3 @@
 const shell = require('shelljs')
 
-shell.exec(`
-  concurrently \
-  "npm run build:css:watch" \
-  "npm run build:esm -- --watch" \
-  "npm run playground:vue"
-`)
+shell.exec('concurrently "npm run build:css:watch" "npm run build:esm -- --watch" "npm run playground:vue"')

--- a/scripts/dev-wc.js
+++ b/scripts/dev-wc.js
@@ -1,8 +1,3 @@
 const shell = require('shelljs')
 
-shell.exec(`
-  concurrently \
-  "npm run build:css:watch" \
-  "npm run build:wc -- --watch" \
-  "npm run playground:html"
-`)
+shell.exec(`concurrently "npm run build:css:watch" "npm run build:wc -- --watch" "npm run playground:html"`)


### PR DESCRIPTION
### Bug Description
Shell script won't execute in Windows environment if written in this format:
```bash
sh some-command \
   --some-flag \
   some-param
```

Instead, shell script must be written within one line:
```bash
sh some-command --some-flag some-param
```