### PR TITLE
Fix: unsupported code features on Web Component build

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -4,5 +4,6 @@
 module.exports = {
   presets: [
     '@vue/cli-plugin-babel/preset'
-  ]
+  ],
+  plugins: ['@babel/plugin-proposal-nullish-coalescing-operator', '@babel/plugin-proposal-optional-chaining'],
 }

--- a/babel.lib.config.js
+++ b/babel.lib.config.js
@@ -10,7 +10,8 @@ module.exports = {
           useBuiltIns: 'entry',
           corejs: '3.6',
         }]
-      ]
+      ],
+      plugins: ['@babel/plugin-proposal-nullish-coalescing-operator', '@babel/plugin-proposal-optional-chaining'],
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -357,8 +357,7 @@
     "@babel/helper-plugin-utils": {
       "version": "7.13.0",
       "resolved": "https://registry.npm.taobao.org/@babel/helper-plugin-utils/download/@babel/helper-plugin-utils-7.13.0.tgz",
-      "integrity": "sha1-gGUmzhJa7QM3O8QWqCgyHjpqM68=",
-      "dev": true
+      "integrity": "sha1-gGUmzhJa7QM3O8QWqCgyHjpqM68="
     },
     "@babel/helper-remap-async-to-generator": {
       "version": "7.14.5",
@@ -961,13 +960,19 @@
       }
     },
     "@babel/plugin-proposal-nullish-coalescing-operator": {
-      "version": "7.14.2",
-      "resolved": "https://registry.nlark.com/@babel/plugin-proposal-nullish-coalescing-operator/download/@babel/plugin-proposal-nullish-coalescing-operator-7.14.2.tgz?cache=0&sync_timestamp=1620845954595&other_urls=https%3A%2F%2Fregistry.nlark.com%2F%40babel%2Fplugin-proposal-nullish-coalescing-operator%2Fdownload%2F%40babel%2Fplugin-proposal-nullish-coalescing-operator-7.14.2.tgz",
-      "integrity": "sha1-QlsR3GL8JpOaKrQsu6aAvfVzRUY=",
-      "dev": true,
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.14.5.tgz",
+      "integrity": "sha512-gun/SOnMqjSb98Nkaq2rTKMwervfdAoz6NphdY0vTfuzMfryj+tDGb2n6UkDKwez+Y8PZDhE3D143v6Gepp4Hg==",
       "requires": {
-        "@babel/helper-plugin-utils": "^7.13.0",
+        "@babel/helper-plugin-utils": "^7.14.5",
         "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3"
+      },
+      "dependencies": {
+        "@babel/helper-plugin-utils": {
+          "version": "7.14.5",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.14.5.tgz",
+          "integrity": "sha512-/37qQCE3K0vvZKwoK4XU/irIJQdIfCJuhU5eKnNxpFDsOkgFaUAwbv+RYw6eYgsC0E4hS7r5KqGULUogqui0fQ=="
+        }
       }
     },
     "@babel/plugin-proposal-numeric-separator": {
@@ -1020,14 +1025,42 @@
       }
     },
     "@babel/plugin-proposal-optional-chaining": {
-      "version": "7.14.2",
-      "resolved": "https://registry.nlark.com/@babel/plugin-proposal-optional-chaining/download/@babel/plugin-proposal-optional-chaining-7.14.2.tgz?cache=0&sync_timestamp=1620845964083&other_urls=https%3A%2F%2Fregistry.nlark.com%2F%40babel%2Fplugin-proposal-optional-chaining%2Fdownload%2F%40babel%2Fplugin-proposal-optional-chaining-7.14.2.tgz",
-      "integrity": "sha1-34FxqLnEPr9MHavmMRtDLYPhs04=",
-      "dev": true,
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.14.5.tgz",
+      "integrity": "sha512-ycz+VOzo2UbWNI1rQXxIuMOzrDdHGrI23fRiz/Si2R4kv2XZQ1BK8ccdHwehMKBlcH/joGW/tzrUmo67gbJHlQ==",
       "requires": {
-        "@babel/helper-plugin-utils": "^7.13.0",
-        "@babel/helper-skip-transparent-expression-wrappers": "^7.12.1",
+        "@babel/helper-plugin-utils": "^7.14.5",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.14.5",
         "@babel/plugin-syntax-optional-chaining": "^7.8.3"
+      },
+      "dependencies": {
+        "@babel/helper-plugin-utils": {
+          "version": "7.14.5",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.14.5.tgz",
+          "integrity": "sha512-/37qQCE3K0vvZKwoK4XU/irIJQdIfCJuhU5eKnNxpFDsOkgFaUAwbv+RYw6eYgsC0E4hS7r5KqGULUogqui0fQ=="
+        },
+        "@babel/helper-skip-transparent-expression-wrappers": {
+          "version": "7.14.5",
+          "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.14.5.tgz",
+          "integrity": "sha512-dmqZB7mrb94PZSAOYtr+ZN5qt5owZIAgqtoTuqiFbHFtxgEcmQlRJVI+bO++fciBunXtB6MK7HrzrfcAzIz2NQ==",
+          "requires": {
+            "@babel/types": "^7.14.5"
+          }
+        },
+        "@babel/helper-validator-identifier": {
+          "version": "7.14.8",
+          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.8.tgz",
+          "integrity": "sha512-ZGy6/XQjllhYQrNw/3zfWRwZCTVSiBLZ9DHVZxn9n2gip/7ab8mv2TWlKPIBk26RwedCBoWdjLmn+t9na2Gcow=="
+        },
+        "@babel/types": {
+          "version": "7.14.8",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.14.8.tgz",
+          "integrity": "sha512-iob4soQa7dZw8nodR/KlOQkPh9S4I8RwCxwRIFuiMRYjOzH/KJzdUfDgz6cGi5dDaclXF4P2PAhCdrBJNIg68Q==",
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.14.8",
+            "to-fast-properties": "^2.0.0"
+          }
+        }
       }
     },
     "@babel/plugin-proposal-private-methods": {
@@ -1352,7 +1385,6 @@
       "version": "7.8.3",
       "resolved": "https://registry.npm.taobao.org/@babel/plugin-syntax-nullish-coalescing-operator/download/@babel/plugin-syntax-nullish-coalescing-operator-7.8.3.tgz",
       "integrity": "sha1-Fn7XA2iIYIH3S1w2xlqIwDtm0ak=",
-      "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.8.0"
       }
@@ -1388,7 +1420,6 @@
       "version": "7.8.3",
       "resolved": "https://registry.npm.taobao.org/@babel/plugin-syntax-optional-chaining/download/@babel/plugin-syntax-optional-chaining-7.8.3.tgz",
       "integrity": "sha1-T2nCq5UWfgGAzVM2YT+MV4j31Io=",
-      "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.8.0"
       }
@@ -16572,7 +16603,7 @@
     },
     "lodash.kebabcase": {
       "version": "4.1.1",
-      "resolved": "https://registry.npm.taobao.org/lodash.kebabcase/download/lodash.kebabcase-4.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz",
       "integrity": "sha1-hImxyw0p/4gZXM7KRI/21swpXDY=",
       "dev": true
     },
@@ -23070,8 +23101,7 @@
     "to-fast-properties": {
       "version": "2.0.0",
       "resolved": "https://registry.npm.taobao.org/to-fast-properties/download/to-fast-properties-2.0.0.tgz",
-      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
-      "dev": true
+      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
     },
     "to-object-path": {
       "version": "0.3.0",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,8 @@
     "lint": "vue-cli-service lint"
   },
   "dependencies": {
+    "@babel/plugin-proposal-nullish-coalescing-operator": "^7.14.5",
+    "@babel/plugin-proposal-optional-chaining": "^7.14.5",
     "@popperjs/core": "^2.9.2",
     "@vue/web-component-wrapper": "^1.3.0",
     "core-js": "^3.6.5",

--- a/package.json
+++ b/package.json
@@ -20,8 +20,6 @@
     "lint": "vue-cli-service lint"
   },
   "dependencies": {
-    "@babel/plugin-proposal-nullish-coalescing-operator": "^7.14.5",
-    "@babel/plugin-proposal-optional-chaining": "^7.14.5",
     "@popperjs/core": "^2.9.2",
     "@vue/web-component-wrapper": "^1.3.0",
     "core-js": "^3.6.5",
@@ -33,6 +31,8 @@
   "devDependencies": {
     "@babel/cli": "^7.14.5",
     "@babel/core": "^7.14.3",
+    "@babel/plugin-proposal-nullish-coalescing-operator": "^7.14.5",
+    "@babel/plugin-proposal-optional-chaining": "^7.14.5",
     "@babel/preset-env": "^7.14.5",
     "@fullhuman/purgecss-loader": "^1.0.0",
     "@storybook/addon-actions": "^6.2.9",

--- a/vue.config.js
+++ b/vue.config.js
@@ -1,12 +1,12 @@
 const path = require('path')
 
-function mergeAppWebpackConfig(config) {
-  config.resolve.alias = config.resolve.alias || {}
-  Object.assign(config.resolve.alias, {
-    '@jabardigitalservice/jds-design-system': path.resolve(__dirname, 'publish')
-  })
-
-  const svgRule = config.module.rules.find((rule) => {
+/**
+ * Insert svg-to-vue loader rule
+ * NOTE: This method mutate provided config argument
+ * @param {*} currentConfig 
+ */
+function modifySvgRule(currentConfig) {
+  const svgRule = currentConfig.module.rules.find((rule) => {
     return rule.test.test('.svg')
   })
 
@@ -29,7 +29,18 @@ function mergeAppWebpackConfig(config) {
   }
 }
 
+function mergeAppWebpackConfig(config) {
+  config.resolve.alias = config.resolve.alias || {}
+  Object.assign(config.resolve.alias, {
+    '@jabardigitalservice/jds-design-system': path.resolve(__dirname, 'publish')
+  })
+  
+  modifySvgRule(config)
+}
+
 function mergeWebComponentWebpackConfig(config) {
+  modifySvgRule(config)
+
   const styleRules = config.module.rules.filter((rule) => {
     return rule.test.test('.scss')
   })


### PR DESCRIPTION
### Issue
Unsupported code features/syntax
![image](https://user-images.githubusercontent.com/20709202/126578604-04839cfd-c90c-4b2b-b6a0-c0077f68c43b.png)
![image](https://user-images.githubusercontent.com/20709202/126578657-e90c3582-5692-44d1-b710-b1f1acb2b396.png)



### Task Description
This code features are not supported on current Web Component build using VueCLI service. 
#### Optional Chaining
```javascript
if (some?.property?.exist?.and?.callable?.()) {
    // do something
}
```

#### Null Coalescing Operator
```javascript
const a = b ?? null
```

#### Converting SVG to Vue Component
`svg-to-vue-loader` has not been set in Web Component build Webpack config.

### Changes
- Add babel plugins
     - `@babel/plugin-proposal-nullish-coalescing-operator`
     - `@babel/plugin-proposal-optional-chaining`
- Refactor `svg-to-vue-loader` webpack config
     
### Preview (Before)
![image](https://user-images.githubusercontent.com/20709202/126579098-27137d4b-4526-4595-8722-6d2743a49310.png)

### Preview (After)
![image](https://user-images.githubusercontent.com/20709202/126579045-92d8ec02-6496-4f6f-a1e0-5057b3a08749.png)
