### PR TITLE
Fix: use relative path imports for SCSS

### DIFF
--- a/src/components/JdsAccordion/Accordion.scss
+++ b/src/components/JdsAccordion/Accordion.scss
@@ -1,4 +1,4 @@
-@use '~/styles/scss/variables' as V;
+@use '../../../styles/scss/variables' as V;
 
 $--accordion-border-radius: 8px;
 $--accordion-border-color: V.$green-800;

--- a/src/components/JdsBadge/Badge.scss
+++ b/src/components/JdsBadge/Badge.scss
@@ -1,4 +1,4 @@
-@use "~/styles/scss/variables" as V;
+@use '../../../styles/scss/variables' as V;
 
 $--badge-size-xs: 10px;
 $--badge-size-sm: 14px;

--- a/src/components/JdsButton/Button.scss
+++ b/src/components/JdsButton/Button.scss
@@ -1,4 +1,4 @@
-@use '~/styles/scss/variables' as V;
+@use '../../../styles/scss/variables' as V;
 
 .jds-button{
   cursor: pointer;

--- a/src/components/JdsCalendar/Calendar.scss
+++ b/src/components/JdsCalendar/Calendar.scss
@@ -1,4 +1,4 @@
-@use "~/styles/scss/variables" as V;
+@use '../../../styles/scss/variables' as V;
 
 .jds-calendar {
   user-select:none;

--- a/src/components/JdsCheckbox/Checkbox.scss
+++ b/src/components/JdsCheckbox/Checkbox.scss
@@ -1,4 +1,4 @@
-@use "~/styles/scss/variables" as V;
+@use '../../../styles/scss/variables' as V;
 
 .jds-checkbox {
   position: relative;

--- a/src/components/JdsCheckboxGroup/CheckboxGroup.scss
+++ b/src/components/JdsCheckboxGroup/CheckboxGroup.scss
@@ -1,4 +1,4 @@
-@use "~/styles/scss/variables" as V;
+@use '../../../styles/scss/variables' as V;
 
 $--checkbox-gap-h: 0.75em;
 $--checkbox-gap-v: 0.75em;

--- a/src/components/JdsCheckboxToggle/CheckboxToggle.scss
+++ b/src/components/JdsCheckboxToggle/CheckboxToggle.scss
@@ -1,4 +1,4 @@
-@use "~/styles/scss/variables" as V;
+@use '../../../styles/scss/variables' as V;
 
 .jds-checkbox-toggle {
   &__icon-wrapper {

--- a/src/components/JdsDateInput/DateInput.scss
+++ b/src/components/JdsDateInput/DateInput.scss
@@ -1,4 +1,4 @@
-@use "~/styles/scss/variables" as V;
+@use '../../../styles/scss/variables' as V;
 
 .jds-date-input {
   display: inline-block;

--- a/src/components/JdsFormControl/FormControlErrorMessage.vue
+++ b/src/components/JdsFormControl/FormControlErrorMessage.vue
@@ -5,7 +5,7 @@
 </template>
 
 <style lang="scss">
-@use "~/styles/scss/variables" as V;
+@use '../../../styles/scss/variables' as V;
 
 .jds-form-control-error-message {
   margin: 0;

--- a/src/components/JdsFormControl/FormControlHelperText.vue
+++ b/src/components/JdsFormControl/FormControlHelperText.vue
@@ -5,7 +5,7 @@
 </template>
 
 <style lang="scss">
-@use "~/styles/scss/variables" as V;
+@use '../../../styles/scss/variables' as V;
 
 .jds-form-control-helper-text {
   overflow: hidden;

--- a/src/components/JdsFormControl/FormControlLabel.vue
+++ b/src/components/JdsFormControl/FormControlLabel.vue
@@ -5,7 +5,7 @@
 </template>
 
 <style lang="scss">
-@use ".~/styles/scss/variables" as V;
+@use '../../../styles/scss/variables' as V;
 
 .jds-form-control-label {
   overflow: hidden;

--- a/src/components/JdsInputText/InputText.scss
+++ b/src/components/JdsInputText/InputText.scss
@@ -1,4 +1,4 @@
-@use "~/styles/scss/variables" as V;
+@use '../../../styles/scss/variables' as V;
 
 @mixin set-input-bg-color($color) {
   .jds-input-text__input-wrapper {

--- a/src/components/JdsInputTextEdge/InputTextEdge.scss
+++ b/src/components/JdsInputTextEdge/InputTextEdge.scss
@@ -1,4 +1,4 @@
-@use "~/styles/scss/variables" as V;
+@use '../../../styles/scss/variables' as V;
 
 // set to (input text border-radius - 1px);
 $--border-radius: 7px;

--- a/src/components/JdsOptions/Options.scss
+++ b/src/components/JdsOptions/Options.scss
@@ -1,4 +1,4 @@
-@use "~/styles/scss/variables" as V;
+@use '../../../styles/scss/variables' as V;
 
 .jds-options {
   display: inline-block;

--- a/src/components/JdsRadioButton/RadioButton.scss
+++ b/src/components/JdsRadioButton/RadioButton.scss
@@ -1,4 +1,4 @@
-@use "~/styles/scss/variables" as V;
+@use '../../../styles/scss/variables' as V;
 
 .jds-radio-button {
   display: flex;

--- a/src/components/JdsSelect/Select.scss
+++ b/src/components/JdsSelect/Select.scss
@@ -1,4 +1,4 @@
-@use "~/styles/scss/variables" as V;
+@use '../../../styles/scss/variables' as V;
 
 .jds-select {
   display: inline-block;

--- a/src/components/JdsSimpleTable/SimpleTable.scss
+++ b/src/components/JdsSimpleTable/SimpleTable.scss
@@ -1,4 +1,4 @@
-@use "~/styles/scss/variables" as V;
+@use '../../../styles/scss/variables' as V;
 
 .jds-simple-table {
   width: 100%;

--- a/src/components/JdsTextArea/TextArea.scss
+++ b/src/components/JdsTextArea/TextArea.scss
@@ -1,4 +1,4 @@
-@use "~/styles/scss/variables" as V;
+@use '../../../styles/scss/variables' as V;
 
 @mixin set-input-border-color($color) {
   .jds-text-area__input-wrapper textarea {

--- a/src/components/JdsToggle/Toggle.scss
+++ b/src/components/JdsToggle/Toggle.scss
@@ -1,4 +1,4 @@
-@use '~/styles/scss/variables' as V;
+@use '../../../styles/scss/variables' as V;
 
 .jds-toggle {
   display: block;


### PR DESCRIPTION
### Task Description
According to this [answer](https://stackoverflow.com/questions/37106230/node-sass-does-not-understand-tilde), `~` in SASS import syntax is actually a webpack feature. When this library is published as a package, all SCSS within each component folder will throw "unresolved module" error.

### Solution
Change all import using relative path, so module can be resolved properly, instead of using webpack resolve alias (`~`).