### PR TITLE
ci: build Storybook and auto accept changes on merge to master

### DIFF
--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -1,0 +1,23 @@
+name: 'Deploy Storybook (Production)'
+
+on:
+  push:
+    branches:
+      - master
+jobs:
+  chromatic:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Install dependencies
+        run: |
+          yarn && yarn build:icons
+        # 👇 Adds Chromatic as a step in the workflow
+      - name: Publish to Chromatic
+        uses: chromaui/action@v1
+        # Chromatic GitHub Action options
+        with:
+          autoAcceptChanges: true
+          token: ${{ secrets.GITHUB_TOKEN }}
+          # 👇 Chromatic projectToken, refer to the manage page to obtain it.
+          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}


### PR DESCRIPTION
### Task Description
As of now, Storybook is only built on Pull Request event, not including Merge (Push) event. This resulted on stale Storybook build on Chromatic.

Storybook built is set to `autoAcceptChanges`, so no further UI Review or UI Test is needed.

### Changes
- Create Storybook deployment workflow that is triggered on merge to master