### PR TITLE
JdsPagination: add disable state for InputText and Select, for Pagination use case

### DIFF
--- a/src/components/JdsInputText/InputText.scss
+++ b/src/components/JdsInputText/InputText.scss
@@ -125,6 +125,20 @@
   &:not(&--focused) {
     @include toggle-input-inset-shadow(false);
   }
+
+
+  &--disabled {
+    @include set-input-bg-color(V.$gray-200);
+
+    &,
+    & * {
+      pointer-events: none;
+    }
+
+    input {
+      color: V.$gray-400;
+    }
+  }
   
   &--error {
     @include set-input-border-color(V.$red-700);

--- a/src/components/JdsInputText/InputText.vue
+++ b/src/components/JdsInputText/InputText.vue
@@ -5,6 +5,7 @@
     'jds-input-text--error': showErrorMsg,
     'jds-input-text--focused': isFocused,
     'jds-input-text--hovered': isHovered,
+    'jds-input-text--disabled': disabled,
   }">
     <jds-form-control-label v-if="showLabel">
       {{ label }}
@@ -40,7 +41,8 @@
         v-bind="inputAttributes"
         type="text"
         :value="mValue"
-        :readonly="$attrs.readonly"
+        :readonly="readonly"
+        :disabled="disabled"
         @input="onInput"
         @change="onChange"
         @focus="onFocus"
@@ -165,7 +167,25 @@ export default {
      */
     suffixConfig: {
       type: Object,
-    }
+    },
+
+    /**
+     * Internal use only
+     * @private
+     * @ignore
+     */
+    disabled: {
+      type: Boolean,
+    },
+
+    /**
+     * Internal use only
+     * @private
+     * @ignore
+     */
+    readonly: {
+      type: Boolean,
+    },
   },
   data () {
     return {

--- a/src/components/JdsPagination/Pagination.scss
+++ b/src/components/JdsPagination/Pagination.scss
@@ -84,6 +84,10 @@
       color: V.$gray-600 !important;
     }
   }
+
+  &--disabled &__navigation-button {
+    cursor: not-allowed;
+  }
 }
 
 @media (min-width: 600px) {

--- a/src/components/JdsPagination/Pagination.scss
+++ b/src/components/JdsPagination/Pagination.scss
@@ -75,14 +75,25 @@
       background: V.$gray-100;
       outline: none;
     }
+
+    &__icon {
+      color: V.$green-800;
+    }
+
+    &:disabled,
+    &[disabled] {
+      cursor: not-allowed;
+    }
+
+    &:disabled &__icon,
+    &[disabled] &__icon {
+      color: V.$gray-400;
+    }
   }
 
   &--disabled {
     background-color: V.$gray-100;
-
-    * {
-      color: V.$gray-600 !important;
-    }
+    color: V.$gray-600;
   }
 
   &--disabled &__navigation-button {
@@ -90,7 +101,7 @@
   }
 }
 
-@media (min-width: 600px) {
+@media (min-width: 650px) {
   .jds-pagination {
     
     &__wrapper {

--- a/src/components/JdsPagination/Pagination.vue
+++ b/src/components/JdsPagination/Pagination.vue
@@ -15,6 +15,7 @@
             class="jds-pagination__page-control__select__input"
             tile
             max-height="200px"
+            :disabled="disabled"
             :options="itemsPerPageOptions"
             :value="mItemsPerPage"
             @change="onItemsPerPageChange"
@@ -48,6 +49,7 @@
             tile
             filterable
             max-height="200px"
+            :disabled="disabled"
             :options="generatedPageNumbers"
             :value="mCurrentPage"
             @change="onPageChange"

--- a/src/components/JdsPagination/Pagination.vue
+++ b/src/components/JdsPagination/Pagination.vue
@@ -32,12 +32,12 @@
       <div class="jds-pagination__page-control--right">
         <button
           class="jds-pagination__navigation-button"
-          :disabled="disabled"
+          :disabled="disabled || !hasPreviousPage"
           @click="onPreviousPage"
         >
           <jds-icon 
             name="chevron-left" 
-            class="text-green-800"
+            class="jds-pagination__navigation-button__icon"
             size="16px" 
           />
         </button>
@@ -49,6 +49,7 @@
             tile
             filterable
             max-height="200px"
+            options-header="Halaman"
             :disabled="disabled"
             :options="generatedPageNumbers"
             :value="mCurrentPage"
@@ -57,10 +58,14 @@
           <span>dari <strong>{{ pages }}</strong></span>
         </div>
         <i class="jds-pagination__divider" />
-        <button class="jds-pagination__navigation-button" :disabled="disabled" @click="onNextPage">
+        <button
+          class="jds-pagination__navigation-button"
+          :disabled="disabled || !hasNextPage"
+          @click="onNextPage"
+        >
           <jds-icon 
             name="chevron-right" 
-            class="text-green-800"
+            class="jds-pagination__navigation-button__icon"
             size="16px"
           />
         </button>
@@ -189,7 +194,13 @@ export default {
         return Math.ceil(parseInt(this.totalRows)/parseInt(this.mItemsPerPage)) 
       }
       return 1
-    }
+    },
+    hasPreviousPage () {
+      return this.mCurrentPage > 1
+    },
+    hasNextPage () {
+      return this.mCurrentPage < this.pages - 1
+    },
   }
 }
 </script>

--- a/src/components/JdsSelect/Select.scss
+++ b/src/components/JdsSelect/Select.scss
@@ -48,4 +48,13 @@
       }
     }
   }
+
+  &--disabled,
+  &--disabled * {
+    cursor: not-allowed;
+  }
+
+  &--disabled &__trigger-icon {
+    color: V.$gray-400;
+  }
 }

--- a/src/components/JdsSelect/Select.vue
+++ b/src/components/JdsSelect/Select.vue
@@ -11,11 +11,13 @@
         'jds-select font-sans-1': true,
         'jds-select--opened': isDropdownOpen,
         'jds-select--tile': tile,
+        'jds-select--disabled': disabled
       }">
         <jds-input-text
           ref="inputText"
           :value="`${selectedOptionLabel}`"
           readonly
+          :disabled="disabled"
           :label="label"
           :placeholder="placeholder"
           :helper-text="helperText"
@@ -222,6 +224,15 @@ export default {
     errorMessage: {
       type: String,
     },
+
+    /**
+     * Internal use only
+     * @private
+     * @ignore
+     */
+    disabled: {
+      type: Boolean,
+    },
   },
   data () {
     return {
@@ -261,6 +272,16 @@ export default {
         const val = this.getOptionValue(opt, this.valueKey)
         return val === this.mValue 
       })
+    },
+  },
+  watch: {
+    disabled: {
+      immediate: true,
+      handler (v) {
+        if (v && this.isDropdownOpen) {
+          this.closeDropdown()
+        }
+      }
     },
   },
   methods: {

--- a/styles/scss/_variables.scss
+++ b/styles/scss/_variables.scss
@@ -82,7 +82,7 @@ $gray-50: #FAFAFA !default;
 $gray-100: #F5F5F5 !default;
 $gray-200: #EEEEEE !default;
 $gray-300: #E0E0E0 !default;
-$gray-400: #9E9E9E !default;
+$gray-400: #BDBDBD !default;
 $gray-500: #9E9E9E !default;
 $gray-600: #757575 !default;
 $gray-700: #616161 !default;


### PR DESCRIPTION
### Task Description
Rework Pagination, in compliance with [Developer Handoff](https://www.figma.com/file/ApxYqXtPhfP4hAlWkUGl4I/JDS---Desktop-Components?node-id=9319%3A87066).

### Changes
- Fix Gray400 color definition. Currently, it is a dupe of Gray500.
- Add `disabled` prop for InputText and Select
- Exclude `disabled` prop on InputText and Select from Storybook, since `disabled` state doesnt actually exist for both component design spec
- Add `disabled` prop for Pagination 
- Disable navigation button when targeted page doesnt exist

### Preview
![image](https://user-images.githubusercontent.com/20709202/130188923-6d72a479-cbf2-4ac4-8cb4-54b7155eace2.png)

![Screen record from 2021-08-20 13 18 08](https://user-images.githubusercontent.com/20709202/130188841-61ab34c4-7eb3-4ef8-b6f3-083951b1199a.gif)

