### PR TITLE
chore: replace arithmetic division with sass:math.div

### DIFF
--- a/src/components/JdsBadge/Badge.scss
+++ b/src/components/JdsBadge/Badge.scss
@@ -1,4 +1,5 @@
 @use '../../../styles/scss/variables' as V;
+@use 'sass:math' as Math;
 
 $--badge-size-xs: 10px;
 $--badge-size-sm: 14px;
@@ -14,13 +15,13 @@ $--badge-size-xl: 32px;
 
 @mixin set-dot-size-position($size) {
   .jds-badge__dot {
-    bottom: calc(100% - #{$size / 2});
+    bottom: calc(100% - #{Math.div($size, 2)});
     width: $size;
     height: $size;
     border-radius: 9999px;
     color: white;
     font-weight: 500;;
-    font-size: $size / 2;
+    font-size: Math.div($size, 2);
   }
 }
 


### PR DESCRIPTION
### Related Issue
[[Deprecated] Pembagian value secara aritmetis akan deprecated di sass@^2](#82 )

### Changes
Replace arithmetic division, e.g `( a / b )` with `math.div(a, b)`