### PR TITLE
Fix: Select and Options in Pagination aren't synced when filter value changed

### DIFF
--- a/src/components/JdsPagination/Pagination.vue
+++ b/src/components/JdsPagination/Pagination.vue
@@ -48,6 +48,7 @@
             class="jds-pagination__page-control__select__input"
             tile
             filterable
+            reset-filter-on-open
             max-height="200px"
             options-header="Halaman"
             :disabled="disabled"

--- a/src/components/JdsSelect/Select.vue
+++ b/src/components/JdsSelect/Select.vue
@@ -57,6 +57,7 @@
         filter: mFilter,
         filterType,
       }"
+      :value="mValue"
       @click:option="onOptionClicked"
       @change="onOptionsValueChanged"
       @change:filter="onOptionsFilterChanged"
@@ -201,6 +202,13 @@ export default {
     },
 
     /**
+     * Reset filter each time dropdown is opened
+     */
+    resetFilterOnOpen: {
+      type: Boolean,
+    },
+
+    /**
      * Select label.
      */
     label: {
@@ -311,6 +319,9 @@ export default {
     },
     openDropdown () {
       this.isDropdownOpen = true
+      if (this.resetFilterOnOpen) {
+        this.mFilter = undefined
+      }
     },
     /**
      * @param {object} options
@@ -442,6 +453,7 @@ export default {
       this.emitChange(this.mValue)
     },
     onOptionsFilterChanged (filter) {
+      this.mFilter = filter
       /**
        * Support `.sync` modifier for `filter` prop.
        * Emitted when filter changed


### PR DESCRIPTION
### Bug
Steps to Repro:
1. Set `totalItems` to 1000
2. Select `3` as current page
3. Change `perPage` to `10`
4. At this point, current page will be resetted to `1`

### Expected
Selected option under page selection should also reflect `1`

### Actual
Selected option under page selection still show previous selected value, which is `3`

### Fix
- Fix data synchronization between Select and Options


### Preview
#### Before

https://user-images.githubusercontent.com/20709202/131089874-3335a3bc-52a5-4a15-9331-c893137f473a.mp4

#### After

https://user-images.githubusercontent.com/20709202/131090114-03b3ad94-a5e6-4b13-be63-c1188ec4b9f7.mp4



