### PR TITLE
Fix: Data Table Styling in compliance with Loading State

### DIFF
--- a/src/components/JdsDataTable/DataTable.scss
+++ b/src/components/JdsDataTable/DataTable.scss
@@ -1,10 +1,13 @@
 @use '../../../styles/scss/variables' as V;
 
 .jds-data-table {
-  height: 100%;
   width: 100%;
   border-spacing: 0 !important;
   border: none;
+
+  &--full-height {
+    height: 100%;
+  }
 
   * {
     font-family: inherit;
@@ -16,6 +19,11 @@
     display: flex;
     align-items: center;
     justify-content: center;
+    height: 100%;
+
+    .jds-spinner {
+      line-height: 0;
+    }
   }
 
   &__empty {

--- a/src/components/JdsDataTable/DataTable.scss
+++ b/src/components/JdsDataTable/DataTable.scss
@@ -5,10 +5,6 @@
   border-spacing: 0 !important;
   border: none;
 
-  &--full-height {
-    height: 100%;
-  }
-
   * {
     font-family: inherit;
     font-size: 14px;
@@ -19,7 +15,6 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    height: 100%;
 
     .jds-spinner {
       line-height: 0;
@@ -71,7 +66,7 @@
       text-align: left;
 
       td {
-        padding: 6px 8px;
+        padding: 10px 8px;
         border-top: 1px solid V.$gray-200;
         color: V.$gray-800;
       }

--- a/src/components/JdsDataTable/DataTable.stories.js
+++ b/src/components/JdsDataTable/DataTable.stories.js
@@ -61,6 +61,9 @@ Default.args = {
   localSort: true,
   loading: false,
   emptyText: '',
+  pagination: {
+    itemsPerPage: 3,
+  }
 }
 
 export const EmptyState = Template.bind({})

--- a/src/components/JdsDataTable/DataTable.stories.js
+++ b/src/components/JdsDataTable/DataTable.stories.js
@@ -20,12 +20,10 @@ const Template = (args, context) => {
     components: { JdsDataTable, JdsSpinner, JdsIcon },
     mixins: [storybookMixin(args, context)],
     template: `
-      <div style="height: 350px">
-        <jds-data-table
-          v-bind="$props" 
-          v-on="events" 
-        />
-      </div>
+      <jds-data-table
+        v-bind="$props" 
+        v-on="events" 
+      />
     `,
   }
 }

--- a/src/components/JdsDataTable/DataTable.stories.js
+++ b/src/components/JdsDataTable/DataTable.stories.js
@@ -7,6 +7,11 @@ import { default as storybookMixin, hideArgTypes, hideEvents } from '../../utils
 export default {
   component: JdsDataTable,
   title: 'Components/DataTable',
+  parameters: {
+    backgrounds: {
+      default: 'gray'
+    },
+  },
 }
 
 const Template = (args, context) => {
@@ -15,10 +20,12 @@ const Template = (args, context) => {
     components: { JdsDataTable, JdsSpinner, JdsIcon },
     mixins: [storybookMixin(args, context)],
     template: `
-      <jds-data-table
-        v-bind="$props" 
-        v-on="events" 
-      />
+      <div style="height: 350px">
+        <jds-data-table
+          v-bind="$props" 
+          v-on="events" 
+        />
+      </div>
     `,
   }
 }

--- a/src/components/JdsDataTable/DataTable.vue
+++ b/src/components/JdsDataTable/DataTable.vue
@@ -1,5 +1,8 @@
 <template>
-  <table :class="[{ 'jds-data-table font-sans-1': true }]">
+  <table :class="{ 
+    'jds-data-table font-sans-1': true,
+    'jds-data-table--full-height': loading,
+  }">
     <thead class="jds-data-table__head">
       <tr>
         <th v-for="(header, index) in headers" :key="index">

--- a/src/components/JdsDataTable/DataTable.vue
+++ b/src/components/JdsDataTable/DataTable.vue
@@ -1,7 +1,6 @@
 <template>
   <table :class="{ 
-    'jds-data-table font-sans-1': true,
-    'jds-data-table--full-height': loading,
+    'jds-data-table font-sans-1': true
   }">
     <thead class="jds-data-table__head">
       <tr>
@@ -34,7 +33,10 @@
       <template v-if="loading">
         <tr>
           <td :colspan="headers.length">
-            <div class="jds-data-table__loading">
+            <div 
+              class="jds-data-table__loading" 
+              :style="getRowHeight"
+            >
               <jds-spinner
                 size="56"
                 background="#E0E0E0"
@@ -142,6 +144,19 @@ export default {
       type: Boolean,
       default: false
     },
+
+    /**
+     * NOTE: 
+     * this property will be changed 
+     * and/or adjusted during implementation and 
+     * integration with JdsPagination component
+     */
+    pagination: {
+      type: Object,
+      default: () => ({
+        itemsPerPage: 10,
+      })
+    }
   },
   computed: {
     isDataEmpty() {
@@ -149,6 +164,12 @@ export default {
         return true
       }
       return false
+    },
+
+    getRowHeight() {
+       // 42px is the minimum height 
+       // of the table rows
+      return { height: `${this.pagination.itemsPerPage * 42}px`}
     }
   }
 }


### PR DESCRIPTION
#### Overview
- ~~According to [Developer Handoff](https://www.figma.com/file/ApxYqXtPhfP4hAlWkUGl4I/JDS---Desktop-Components?node-id=9725%3A91191) Acceptance Criteria, the table body should take 100% of the parent height when loading state is true~~

- After some discussion with @adrianpdm and Arfian (UID), the Table Body **height** when on a **loading state** should be based on how many items will be shown per page. In order to determine the height, we use this calculation :

```
minimumRowHeight = 42px

Body Height = minimumRowHeight * itemsPerPage 
``` 


#### Preview
![dynamic height](https://user-images.githubusercontent.com/33661143/132309576-d3f21285-ce76-4d2a-b8c6-e95d022d0faf.gif)


#### Changes
- ~~Add class modifier `jds-data-table--full-height` to `jds-data-table` when loading is true~~ 
- ~~Add Wrapping container to `jds-data-table` storybook~~

- Add Background Color on Storybook to improve contrast between component and the background
- Add `getRowHeight` computed to calculate table body height when on a loading state
- Add `pagination` property on Data Table Component (Will be adjusted and improved in the future)
- Remove class modifier and adjust table column padding

cc @adrianpdm @adzharamrullah 