### PR TITLE
Proposed Solution #2: make JdsButton colors customizable

### DIFF
--- a/src/components/JdsButton/Button.vue
+++ b/src/components/JdsButton/Button.vue
@@ -3,7 +3,7 @@
   :class="[{
     'jds-button': true,
     'font-sans-1': true,
-  }, classVariant]"
+  }, classVariant, customClass]"
   @click="onButtonClick"
   >
     {{ label }}
@@ -17,6 +17,12 @@
 export default {
   name: 'jds-button',
   props: {
+    /**
+     * Class for custom style passed the component
+     */
+    classes: {
+      type: Object
+    },
     /**
      * The type for the button
      * value is `button | submit`
@@ -40,6 +46,13 @@ export default {
     }
   },
   computed:{
+    customClass(){
+      const { button } = this.classes || {}
+      if(button){
+        return button
+      }
+      return ''
+    },
     // class variant
     classVariant(){
       return {


### PR DESCRIPTION
## Related Issue
#77 Custom warna komponen button masih sulit harus manual

## Proposed Solution
### How to Customize JDSButton Colors
Simply define corresponding CSS variables using JdsButton `style` attributes.
```vue
// template
<jds-button
    :classes="{
        'button': 'jds-button-custom',
    }"
>
</jds-button>

//style
<style>
.jds-button-custom{
    background-color: black
}
</style>
``` 

### Customization Result

### Pros
- Colors are easily overridden using CSS variables, define at root component element using `style` attribute.
- All customizable colors are defined upfront.
- Props are not being polluted by color customization definition

### Cons
- All customizable colors must be defined upfront.
- Each overridable CSS variable within a component must be documented
- Dynamic color that is a result of Javascript logic must also be sync'd into root element CSS variables (instead of binding directly into element attribute).
