### PR TITLE
Feature : Integration with JdsPagination

### DIFF
--- a/src/components/JdsDataTable/DataTable.stories.js
+++ b/src/components/JdsDataTable/DataTable.stories.js
@@ -60,8 +60,12 @@ Default.args = {
   itemKey: 'id',
   emptyText: '',
   pagination: {
-    itemsPerPage: 3,
-  }
+    currentPage: 1,
+    totalRows: 200,
+    itemsPerPage: 10,
+    itemsPerPageOptions: [10, 20, 30, 40, 50],
+    disabled: false
+  },
 }
 
 export const EmptyState = Template.bind({})

--- a/src/components/JdsDataTable/DataTable.vue
+++ b/src/components/JdsDataTable/DataTable.vue
@@ -104,11 +104,7 @@
         <tr>
           <td :colspan="columnLength">
             <jds-pagination
-              :current-page="pagination.currentPage"
-              :total-rows="pagination.totalRows"
-              :items-per-page="pagination.itemsPerPage"
-              :items-per-page-options="pagination.itemsPerPageOptions"
-              :disabled="pagination.disabled"
+              v-bind="pagination"
               @next-page="$emit('next-page', $event)"
               @previous-page="$emit('previous-page', $event)"
               @page-change="$emit('page-change', $event)"
@@ -129,6 +125,12 @@ import JdsPagination from '../JdsPagination'
 import localCopy from '../../mixins/local-copy'
 import sortMixin from './mixins/sort'
 import selectMixin from './mixins/select'
+
+const paginationDefault = {
+  currentPage: 1,
+  totalRows: 0,
+  itemsPerPage: 10
+}
 
 export default {
   name: 'jds-data-table',
@@ -220,12 +222,15 @@ export default {
     */
     pagination: {
       type: Object,
+      validator: pagination => Object.keys(paginationDefault).every(key => {
+        const bool = key in pagination
+        if (!bool) {
+          console.warn(`JdsDataTable: Expected ${key} property on pagination props`)
+        }
+        return bool
+      }),
       default: () => ({
-        currentPage: 1,
-        totalRows: 0,
-        itemsPerPage: 10,
-        itemsPerPageOptions: [10, 20, 30, 40, 50],
-        disabled: false
+        ...paginationDefault
       })
     }
   },

--- a/src/components/JdsDataTable/DataTable.vue
+++ b/src/components/JdsDataTable/DataTable.vue
@@ -100,7 +100,23 @@
       <!-- 
         @slot use this slot for any footer content you want.
       -->
-      <slot name="footer"></slot>
+      <slot name="footer">
+        <tr>
+          <td :colspan="columnLength">
+            <jds-pagination
+              :current-page="pagination.currentPage"
+              :total-rows="pagination.totalRows"
+              :items-per-page="pagination.itemsPerPage"
+              :items-per-page-options="pagination.itemsPerPageOptions"
+              :disabled="pagination.disabled"
+              @next-page="$emit('next-page', $event)"
+              @previous-page="$emit('previous-page', $event)"
+              @page-change="$emit('page-change', $event)"
+              @per-page-change="$emit('per-page-change', $event)"
+            />
+          </td>
+        </tr>
+      </slot>
     </tfoot>
   </table>
 </template>
@@ -109,6 +125,7 @@
 import JdsIcon from '../JdsIcon'
 import JdsSpinner from '../JdsSpinner'
 import JdsCheckboxToggle from '../JdsCheckboxToggle'
+import JdsPagination from '../JdsPagination'
 import localCopy from '../../mixins/local-copy'
 import sortMixin from './mixins/sort'
 import selectMixin from './mixins/select'
@@ -118,7 +135,8 @@ export default {
   components: {
     JdsIcon, 
     JdsSpinner, 
-    JdsCheckboxToggle
+    JdsCheckboxToggle,
+    JdsPagination
   },
   data() {
     return {
@@ -194,15 +212,20 @@ export default {
       default: 'id'
     }, 
 
-     /** NOTE: 
-      * this property will be changed 
-      * and/or adjusted during implementation and 
-      * integration with JdsPagination component
-     */
+   /**
+    * Pagination property
+    * <br><br>
+    * for more information, check
+    * `JdsPagination` component documentation
+    */
     pagination: {
       type: Object,
       default: () => ({
+        currentPage: 1,
+        totalRows: 0,
         itemsPerPage: 10,
+        itemsPerPageOptions: [10, 20, 30, 40, 50],
+        disabled: false
       })
     }
   },

--- a/src/components/JdsDataTable/DataTable.vue
+++ b/src/components/JdsDataTable/DataTable.vue
@@ -245,10 +245,14 @@ export default {
     },
 
     loadingHeight() {
-       // 42px is the minimum height 
-       // of the table rows
-      return { height: `${this.pagination.itemsPerPage * 42}px` }
-    }
+    /**
+     * 42px is the minimum height
+     * of the table rows
+     * 
+     * 10 is the default value of
+     * items per page
+     */
+    return { height: `${(this.pagination?.itemsPerPage || 10) * 42}px` }
   }
 }
 </script>

--- a/src/components/JdsDataTable/DataTable.vue
+++ b/src/components/JdsDataTable/DataTable.vue
@@ -252,7 +252,8 @@ export default {
      * 10 is the default value of
      * items per page
      */
-    return { height: `${(this.pagination?.itemsPerPage || 10) * 42}px` }
+      return { height: `${(this.pagination?.itemsPerPage || 10) * 42}px` }
+    }
   }
 }
 </script>


### PR DESCRIPTION
#### Related
[Developer Handoff](https://www.figma.com/file/ApxYqXtPhfP4hAlWkUGl4I/JDS---Desktop-Components?node-id=9725%3A91191)

#### Overview
Integration with `JdsPagination` component

#### Preview
![Components-DataTable-Default-⋅-Storybook](https://user-images.githubusercontent.com/33661143/132799097-c9e7e875-247a-45e9-85e3-131ec2a93dde.png)


#### Changes
- add `JdsPagination` component
- improve `pagination` props
- fix `loadingHeight` not working correctly when `pagination` object doesn't have `itemsPerPage` property
- add `pagination` props to storybook

NOTE:
- for now it is only support server side pagination