### PR TITLE
Storybook: Table Action with Scoped Slots

### DIFF
--- a/src/components/JdsDataTable/DataTable.stories.js
+++ b/src/components/JdsDataTable/DataTable.stories.js
@@ -1,4 +1,5 @@
 import JdsDataTable from './DataTable.vue'
+import JdsButton from '../JdsButton/Button.vue'
 
 import { default as storybookMixin, hideArgTypes, hideEvents } from '../../utils/storybook'
 
@@ -15,13 +16,17 @@ export default {
 const Template = (args, context) => {
   return {
     name: 'JdsDataTableStories',
-    components: { JdsDataTable },
+    components: { JdsDataTable, JdsButton },
     mixins: [storybookMixin(args, context)],
     template: `
       <jds-data-table
         v-bind="$props" 
         v-on="events" 
-      />
+      >
+        <template #item.action="{ item }"> 
+          <jds-button variant="primary">Click Me</jds-button>
+        </template>
+      </jds-data-table>
     `,
   }
 }
@@ -32,7 +37,7 @@ Default.args = {
     { key: 'id', text: 'ID', sortable: true },
     { key: 'name', text: 'Name', sortable: true },
     { key: 'email', text: 'Email', sortable: true },
-    { key: 'body', text: 'Comments', sortable: true },
+    { key: 'body', text: 'Comments', sortable: true }
   ],
   items: [
     {
@@ -81,9 +86,59 @@ hideArgTypes(EmptyState, [
   'localSort',
   'showSelect',
   'itemKey',
-  'loading'
+  'loading',
+  'pagination',
+  'next-page',
+  'previous-page',
+  'page-change',
+  'per-page-change'
 ])
 hideEvents(EmptyState, [
+  'change:sort',
+  'change:select'
+])
+
+export const WithAction = Template.bind({})
+WithAction.args = {
+  ...Default.args,
+  headers: [
+    ...Default.args.headers,
+    { key: 'action', text: 'Action' },
+  ]
+}
+WithAction.storyName = 'With Action'
+
+const actionSlotDocs = `
+<template>
+  <jds-data-table>
+    <template v-slot:item.action="{ item }">
+      <jds-button variant="primary">Click Me</jds-button>
+    </template>
+  </jds-data-table>
+</template>
+`
+
+WithAction.parameters = {
+  docs: {
+    source: {
+      code: actionSlotDocs
+    }
+  }
+}
+hideArgTypes(WithAction, [
+  'items',
+  'localSort',
+  'showSelect',
+  'itemKey',
+  'loading',
+  'emptyText',
+  'pagination',
+  'next-page',
+  'previous-page',
+  'page-change',
+  'per-page-change'
+])
+hideEvents(WithAction, [
   'change:sort',
   'change:select'
 ])

--- a/src/components/JdsDataTable/DataTable.stories.js
+++ b/src/components/JdsDataTable/DataTable.stories.js
@@ -142,3 +142,4 @@ hideEvents(WithAction, [
   'change:sort',
   'change:select'
 ])
+


### PR DESCRIPTION
#### Related
[Developer Handoff Jds Data Table Component](https://www.figma.com/file/ApxYqXtPhfP4hAlWkUGl4I/JDS---Desktop-Components?node-id=9725%3A91191)

#### Overview
Developer can add **CRUD Actions** to `Jds Data Table` component using [Vue Scoped Slots](https://vuejs.org/v2/guide/components-slots.html#Scoped-Slots). This approach is more flexible than providing props to render either **buttons** or **drop-down menus**. This will also give the developer complete control over the behavior and appearance of the action component.

#### Storybook Preview and Code Snippet
![Components-DataTable-With-Action-⋅-Storybook](https://user-images.githubusercontent.com/33661143/133061587-6719e296-b70c-4bda-bd18-593de17b7b57.png)


#### Usage
```html
<template>
  <jds-data-table>
    <template v-slot:item.action="{ item }">
    
      <! -- add any component you want  --> 
      <jds-button variant="primary" @click="onClick(item.id)">Click Me</jds-button>
      
    </template>
  </jds-data-table>
</template>
```

#### Cons
- Scoped Slots are Vue.js specific concept, for now it will not work with Web Component
https://github.com/webcomponents-cg/community-protocols/issues/8



### Evidence

Title: Jds Data Table Action with Scoped Slots
Project: Jabar Design System
Peserta: @maruf12 @adzharamrullah @adrianpdm @Arif9878 @bangunbagustapa @yoslie @Ibwedagama 