### PR TITLE
JDS Date Input : Add strict validations on parse date

### DIFF
--- a/src/utils/date-input.js
+++ b/src/utils/date-input.js
@@ -29,6 +29,7 @@ const optionMask = {
       mask: IMask.MaskedRange,
       from: 1900,
       to: 9999,
+      maxLength: 4,
     }
   },
   format: formatDate,
@@ -50,10 +51,20 @@ function formatDate(date){
 /**
  * Parsing Date
  * @param {String} date 
- * @returns {Date} Returns Date object. Returns null what date string is invalid or doesn't match format
+ * @returns {Date} Return date object or return null if date string is invalid or doesn't match format
  */
 function parseDate(date){
-  return parse(date, 'DD/MM/YYYY')
+  const parseDate = parse(date, 'DD/MM/YYYY')
+  if(parseDate){
+    const arrayDate = date.split("/")
+    return (
+      arrayDate[0].length > 2 || 
+      arrayDate[1].length > 2 || 
+      arrayDate[2].length > 4 || 
+      parseInt(arrayDate[2]) < 1900
+    ) ? null : parseDate
+  }
+  return parseDate
 }
 
 /**

--- a/src/utils/date-input.js
+++ b/src/utils/date-input.js
@@ -1,4 +1,7 @@
-import IMask from 'imask';
+import IMask from 'imask/esm/imask' 
+import 'imask/esm/masked/regexp'
+import 'imask/esm/masked/date'
+
 import { format, parse } from 'fecha';
 
 


### PR DESCRIPTION
## Changes

- Change way of import imask library to tree shaking esm import
- Add strict validations to parse date utility

### Notes
It is assumed that the year on the date cannot be less than 1900

title: JDS Date Input : Add strict validations on parse date
project: Jabar Design System
participants: @adzharamrullah 