### PR TITLE
Improve: Inherit attributes to text area

### DIFF
--- a/src/components/JdsTextArea/TextArea.scss
+++ b/src/components/JdsTextArea/TextArea.scss
@@ -38,7 +38,7 @@
     margin: 4px 0;
 
     textarea {
-      max-width: 100%;
+      box-sizing: border-box;
       padding: 10px 8px;
       border-radius: 6px;
       color: V.$gray-800;

--- a/src/components/JdsTextArea/TextArea.vue
+++ b/src/components/JdsTextArea/TextArea.vue
@@ -20,7 +20,7 @@
       @mouseleave="isHovered = false"
     >
       <textarea
-        v-bind="{...$props, ...$attrs}"
+        v-bind="{...inputAttributes, ...$attrs}"
         :value="mValue"
         @input="onInput"
         @focus="isFocused = true"
@@ -119,6 +119,13 @@ export default {
     },
   },
   computed: {
+    inputAttributes() {
+      const attrs = ['name', 'placeholder']
+      return attrs.reduce((obj, key) => {
+        obj[key] = this[key]
+        return obj
+      }, {})
+    },
     showLabel() {
       return isStringDefined(this.label)
     },

--- a/src/components/JdsTextArea/TextArea.vue
+++ b/src/components/JdsTextArea/TextArea.vue
@@ -20,8 +20,7 @@
       @mouseleave="isHovered = false"
     >
       <textarea
-        rows="7"
-        v-bind="inputAttributes"
+        v-bind="{...$props, ...$attrs}"
         :value="mValue"
         @input="onInput"
         @focus="isFocused = true"
@@ -58,6 +57,7 @@ export default {
     JdsFormControlHelperText,
   },
   name: 'jds-text-area',
+  inheritAttrs: false,
   props: {
     /**
      * Bound model.
@@ -119,13 +119,6 @@ export default {
     },
   },
   computed: {
-    inputAttributes() {
-      const attrs = ['name', 'placeholder']
-      return attrs.reduce((obj, key) => {
-        obj[key] = this[key]
-        return obj
-      }, {})
-    },
     showLabel() {
       return isStringDefined(this.label)
     },


### PR DESCRIPTION
#### Overview
This PR is the proposed solution to solve this [Feature Request](https://github.com/jabardigitalservice/jds-design-system-vue-lib/issues/110)

Previously the `JdsTextArea` component did not inherit all the native attributes of the text area, so adding the `cols, rows, maxLength, etc` properties did not change the behavior of the `JdsTextArea`. To solve this problem simply bind `$attrs` along with the computed property `inputAttributes`.

#### Changes
- add `box-sizing: border-box` to `text-area` to make sure the padding isn't messing with JdsTextArea width
- binding `$attrs` to text-area

#### Preview

```html
<jds-text-area
  v-model="textarea"
  name="my-textarea"
  placeholder="ini placeholdernya"
  label="My Label"
  helperText="this is helper text"
  errorMessage="this is error message"
  rows="10"
  cols="20"
  maxLength="1500"
/>
``` 

![Jabar-Design-System-Vue-Playground](https://user-images.githubusercontent.com/33661143/134284878-0edc79d0-5edb-4914-a0e8-578a5ccd042e.png)


## Evidence

project: Jabar Design System
title: Improvement Component JdsTextArea
participants: @adzharamrullah @ArifWicakSon @yoslie @bangunbagustapa @maulanayuseph @adrianpdm @Ibwedagama 