### PR TITLE
Fix: bind button type props in jds button component

### DIFF
--- a/src/components/JdsButton/Button.vue
+++ b/src/components/JdsButton/Button.vue
@@ -1,5 +1,6 @@
 <template>
   <button 
+  :type="type"
   :class="[{
     'jds-button': true,
     'font-sans-1': true,

--- a/src/components/JdsButton/Button.vue
+++ b/src/components/JdsButton/Button.vue
@@ -1,11 +1,11 @@
 <template>
   <button 
-  :type="type"
   :class="[{
     'jds-button': true,
     'font-sans-1': true,
   }, classVariant]"
   v-on="$listeners"
+  v-bind="$attrs"
   >
     {{ label }}
     <!-- 
@@ -18,14 +18,6 @@
 export default {
   name: 'jds-button',
   props: {
-    /**
-     * The type for the button
-     * value is `button | submit`
-     */
-    type: {
-      type: String,
-      default: 'button'
-    },
     /**
      * The label for the button
      */


### PR DESCRIPTION
#### Related Issue

#127 Default button type pada jds button

#### Overview

Previously, the button type props has been defined but not bind yet into the component itself.

#### Evidence

Project: Jabar Design System
Title: Fix bind button type props in jds button component
participants: 